### PR TITLE
fix CalloutMarker, LineMarker, TextMarker were throw error when change…

### DIFF
--- a/src/markers/callout-marker/CalloutMarker.ts
+++ b/src/markers/callout-marker/CalloutMarker.ts
@@ -181,8 +181,10 @@ export class CalloutMarker extends TextMarker {
    * @param color - new background color.
    */
   protected setBgColor(color: string): void {
-    SvgHelper.setAttributes(this.bgRectangle, [['fill', color]]);
-    SvgHelper.setAttributes(this.tip, [['fill', color]]);
+    if(this.bgRectangle && this.tip) {
+      SvgHelper.setAttributes(this.bgRectangle, [['fill', color]]);
+      SvgHelper.setAttributes(this.tip, [['fill', color]]);
+    }
     this.bgColor = color;
     this.fillColorChanged(color);
   }

--- a/src/markers/line-marker/LineMarker.ts
+++ b/src/markers/line-marker/LineMarker.ts
@@ -168,19 +168,20 @@ export class LineMarker extends LinearMarkerBase {
    * Adjusts visual after manipulation.
    */
   protected adjustVisual(): void {
-    this.selectorLine.setAttribute('x1', this.x1.toString());
-    this.selectorLine.setAttribute('y1', this.y1.toString());
-    this.selectorLine.setAttribute('x2', this.x2.toString());
-    this.selectorLine.setAttribute('y2', this.y2.toString());
-
-    this.visibleLine.setAttribute('x1', this.x1.toString());
-    this.visibleLine.setAttribute('y1', this.y1.toString());
-    this.visibleLine.setAttribute('x2', this.x2.toString());
-    this.visibleLine.setAttribute('y2', this.y2.toString());
-
-    SvgHelper.setAttributes(this.visibleLine, [['stroke', this.strokeColor]]);
-    SvgHelper.setAttributes(this.visibleLine, [['stroke-width', this.strokeWidth.toString()]]);
-    SvgHelper.setAttributes(this.visibleLine, [['stroke-dasharray', this.strokeDasharray.toString()]]);
+    if(this.selectorLine) {
+      this.selectorLine.setAttribute('x1', this.x1.toString());
+      this.selectorLine.setAttribute('y1', this.y1.toString());
+      this.selectorLine.setAttribute('x2', this.x2.toString());
+      this.selectorLine.setAttribute('y2', this.y2.toString());
+  
+      this.visibleLine.setAttribute('x1', this.x1.toString());
+      this.visibleLine.setAttribute('y1', this.y1.toString());
+      this.visibleLine.setAttribute('x2', this.x2.toString());
+      this.visibleLine.setAttribute('y2', this.y2.toString());
+      SvgHelper.setAttributes(this.visibleLine, [['stroke', this.strokeColor]]);
+      SvgHelper.setAttributes(this.visibleLine, [['stroke-width', this.strokeWidth.toString()]]);
+      SvgHelper.setAttributes(this.visibleLine, [['stroke-dasharray', this.strokeDasharray.toString()]]);
+    }
   }
 
   /**

--- a/src/markers/text-marker/TextMarker.ts
+++ b/src/markers/text-marker/TextMarker.ts
@@ -389,7 +389,9 @@ export class TextMarker extends RectangularBoxMarkerBase {
    * @param color - new text color.
    */
   protected setColor(color: string): void {
-    SvgHelper.setAttributes(this.textElement, [['fill', color]]);
+    if(this.textElement) {
+      SvgHelper.setAttributes(this.textElement, [['fill', color]]);
+    }
     this.color = color;
     if (this.textEditor) {
       this.textEditor.style.color = this.color;


### PR DESCRIPTION
 When selected CalloutMarker, LineMarker, TextMarker, and changeColor without draw marker, it will throw an error about 'Cannot read property 'setAttribute' of undefined'.
So I added a judge when it will execute 'xxx.setAttribute'.
